### PR TITLE
Uninstall NPM @next/eslint-plugin-next

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -362,15 +362,6 @@
       "resolved": "https://registry.npmjs.org/@next/env/-/env-11.1.0.tgz",
       "integrity": "sha512-zPJkMFRenSf7BLlVee8987G0qQXAhxy7k+Lb/5hLAGkPVHAHm+oFFeL+2ipbI2KTEFlazdmGY0M+AlLQn7pWaw=="
     },
-    "@next/eslint-plugin-next": {
-      "version": "11.1.0",
-      "resolved": "https://registry.npmjs.org/@next/eslint-plugin-next/-/eslint-plugin-next-11.1.0.tgz",
-      "integrity": "sha512-HjLhyshV+ANzTDCFLN1UZMQIyYwZkCdhydfIcOQQVCrqLSd0hCi+AYIGqWfDPhXmP7aeOuKQsmhRmdennQV2qw==",
-      "dev": true,
-      "requires": {
-        "glob": "7.1.7"
-      }
-    },
     "@next/polyfill-module": {
       "version": "11.1.0",
       "resolved": "https://registry.npmjs.org/@next/polyfill-module/-/polyfill-module-11.1.0.tgz",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,6 @@
     "theme-ui": "^0.10.0"
   },
   "devDependencies": {
-    "@next/eslint-plugin-next": "^11.1.0",
     "@theme-ui/color": "^0.10.0",
     "date-fns": "^2.21.3",
     "eslint": "^7.32.0",


### PR DESCRIPTION
This PR was created to fix an issue where my Vercel deployments resulted in these 404 pages:. 

<img width="528" alt="Screenshot 2021-08-29 at 10 27 23 PM" src="https://user-images.githubusercontent.com/20778143/131280918-fcc92967-3bfe-4110-9d18-d789826411ee.png">

Turns out, deploying through my personal Vercel account instead of through a team fixed this! 

Now this PR just removes an unnecessary npm package I thought might help with the deployment

see: https://stackoverflow.com/a/68979081/4053142 for more details on this matter and the solution I had