### PR TITLE
[Contact] add Google reCAPTCHA v2 Privacy Policy & Terms of Service

### DIFF
--- a/src/components/sections/contact/Form.js
+++ b/src/components/sections/contact/Form.js
@@ -61,16 +61,42 @@ function ContactForm() {
   }
 
   const reCaptcha = (
-    <ReCAPTCHA
-      ref={recaptchaRef}
-      size="invisible"
-      sitekey={reCaptchaV2Key}
-      sx={{
-        '.grecaptcha-badge': {
-          visibility: 'hidden',
-        },
-      }}
-    />
+    <div sx={{
+      fontSize: 0,
+      textAlign: 'right',
+      height: 'fit-content',
+      alignSelf: 'flex-end',
+      pr: [0, 4, 4],
+      color: (t) => t.colors.contactDivider,
+    }}
+    >
+      <ReCAPTCHA
+        ref={recaptchaRef}
+        size="invisible"
+        sitekey={reCaptchaV2Key}
+        sx={{
+          '.grecaptcha-badge': {
+            visibility: 'hidden',
+          },
+        }}
+      />
+      This site is protected by reCAPTCHA and the
+      <br />
+      {' '}
+      Google
+      {' '}
+      <a href="https://policies.google.com/privacy" sx={{ variant: 'text.link' }}>
+        Privacy Policy
+      </a>
+      {' '}
+      and
+      {' '}
+      <a href="https://policies.google.com/terms" sx={{ variant: 'text.link' }}>
+        Terms of Service
+      </a>
+      {' '}
+      apply.
+    </div>
   );
 
   return (


### PR DESCRIPTION
We can hide the reCAPTCHA UI as long as we display the following "Privacy Policy" and "Terms of Service" links as mentioned in the following link:
https://developers.google.com/recaptcha/docs/faq#id-like-to-hide-the-recaptcha-badge.-what-is-allowed